### PR TITLE
#25 fix rule file

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,17 +1,8 @@
 rules_version = '2';
 service cloud.firestore {
-  match /databases/{database}/documents {
-
-    // This rule allows anyone on the internet to view, edit, and delete
-    // all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // your app will lose access to your Firestore database
-    match /{document=**} {
-      allow read, write: if request.time < timestamp.date(2020, 4, 30);
+    match /databases/{database}/documents {
+        match /users/{userID=**} {
+            allow read,write : if request.auth.uid == userID
     }
   }
 }


### PR DESCRIPTION
## 親チケット
- #25
## 概要
syntax erro はなさそうなのでいったんこれで行くことにした
![image](https://user-images.githubusercontent.com/40349284/83584236-7b868880-a581-11ea-9054-63a110c3871d.png)
```
rules_version = '2';
service cloud.firestore {
  match /databases/{database}/documents {
		match /users/{userID=**} {
    	allow read,write : if request.auth.uid == userID
    }
  }
}
```